### PR TITLE
Matching Slim's support for HTTP methods

### DIFF
--- a/Rephlect/Rephlect.php
+++ b/Rephlect/Rephlect.php
@@ -5,6 +5,7 @@ use Slim\Middleware;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Rephlect\Routes\Loader as RoutesLoader;
+use Rephlect\Routes\Route;
 
 /**
  * Class Rephlect
@@ -43,16 +44,16 @@ class Rephlect extends Middleware
      */
     public function call()
     {
-        $this->app->hook('slim.before.router', array($this, 'mapRoutes'));
+        $this->app->hook('slim.before.router', array($this, 'mapResources'));
         $this->next->call();
     }
 
     /**
      * Maps the routes from the resources defined during instantiation.
      */
-    public function mapRoutes()
+    public function mapResources()
     {
-        array_walk($this->resources, array($this, 'mapRoute'));
+        array_walk($this->resources, array($this, 'mapResource'));
     }
 
     /**
@@ -63,7 +64,7 @@ class Rephlect extends Middleware
      *
      * @param string $resource The resource's fully qualified class name, per the PSR-4 autoloading standard.
      */
-    public function mapRoute($resource)
+    public function mapResource($resource)
     {
         AnnotationRegistry::registerLoader('class_exists');
         $reader = new SimpleAnnotationReader();
@@ -72,20 +73,38 @@ class Rephlect extends Middleware
         $loader = new RoutesLoader($reader);
         $routes = $loader->load($resource);
 
-        foreach ($routes as $route) {
-            $route->app = $this->app;
+        /**
+         * The callable passed to iterator_apply must return true in order to continue applying the function. Since
+         * neither Rephlect::mapResources() nor Rephlect::mapResource() return anything, it would be awkward if
+         * Rephlect::mapRoute() had to. Wrap the call to Rephlect::mapRoute() so that Rephlect::mapRoute() can be a void
+         * function, which keeps the API consistent in the event that Rephlect::mapRoute() is used outside this class.
+         */
+        $self = $this;
+        iterator_apply($routes, function(Route $route) use ($self) {
+            $self->mapRoute($route);
+            return true;
+        });
+    }
 
-            // use Slim::map() if it's a custom verb
-            $isCustomVerb = !in_array($route->verb, static::$verbs);
-            $method = $isCustomVerb ? 'map' : $route->verb;
-            $mappedRoute = $this->app->{$method}($route->path, array($route, 'handle'));
+    /**
+     * Maps a single route to the application.
+     *
+     * @param Route $route
+     */
+    public function mapRoute(Route $route)
+    {
+        $route->app = $this->app;
 
-            // need to specify the verb on the route when it's custom
-            if ($isCustomVerb) {
-                $mappedRoute->via(strtoupper($route->verb));
-            }
+        // use Slim::map() if it's a custom verb
+        $isCustomVerb = !in_array($route->verb, static::$verbs);
+        $method = $isCustomVerb ? 'map' : $route->verb;
+        $mappedRoute = $this->app->{$method}($route->path, array($route, 'handle'));
 
-            $mappedRoute->conditions($route->conditions);
+        // need to specify the verb on the route when it's custom
+        if ($isCustomVerb) {
+            $mappedRoute->via(strtoupper($route->verb));
         }
+
+        $mappedRoute->conditions($route->conditions);
     }
 }

--- a/Rephlect/Routes/Route.php
+++ b/Rephlect/Routes/Route.php
@@ -123,25 +123,19 @@ class Route
     /**
      * Sets the verb.
      *
-     * The verb must be one of the allowed HTTP verbs. Defaults to "get" when empty.
+     * Defaults to "get" when empty.
      *
      * @param string $verb
      * @throws \InvalidArgumentException
      */
     protected function setVerb($verb)
     {
-        $allowedVerbs = array('get', 'post', 'put', 'patch', 'delete');
-
         if (!is_string($verb) && !is_null($verb)) {
             throw new \InvalidArgumentException(sprintf('"%s" is an invalid HTTP verb.', $verb));
         }
 
         if (empty($verb)) {
             $verb = 'get';
-        }
-
-        if (!in_array($verb, $allowedVerbs)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is an invalid HTTP verb.', $verb));
         }
 
         $this->verb = $verb;


### PR DESCRIPTION
- `OPTIONS` and `ANY` are now supported.
- Custom methods can also be used, however unlikely.
- Also, took the opportunity to refactor `Rephlect:: mapResource` so that there is clearer distinction between mapping of resources and mapping of routes.
